### PR TITLE
Dockerize setup with Grafana, Loki, and Promtail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # devops-assignment
 This is for Assignment Task
+
+## Instructions for Deploying the Setup using CI/CD Pipeline
+
+1. Ensure you have Docker and Docker Compose installed on your machine.
+2. Clone the repository to your local machine.
+3. Navigate to the directory containing the `docker-compose.yml` file.
+4. Run the following command to start the services:
+   ```sh
+   docker-compose up -d
+   ```
+5. Access Grafana by navigating to `http://localhost:3000` in your web browser.
+6. Log in with the default credentials (username: `admin`, password: `admin`).
+7. Configure your data sources and dashboards as needed.
+
+## Information about the Filters for Log Visualization
+
+The setup includes the following filters for log visualization:
+
+- `observed_timestamp_rfc3339`: The timestamp when the log was observed, in RFC3339 format.
+- `instrumentation_scope`: The scope of the instrumentation that generated the log.
+- `severity_text`: The severity level of the log message.
+
+These filters are configured in the following files:
+
+- `promtail/config.yml`: Configures Promtail to send logs to Loki with the specified filters.
+- `grafana/provisioning/datasources/datasource.yml`: Configures Grafana to use Loki as a data source with the specified filters.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning  # Mount provisioning config
       - grafana-storage:/var/lib/grafana  # Save dashboards/plugins
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin  # Grafana admin password
     depends_on:
       - loki  # Grafana waits for Loki to be ready
     restart: always
@@ -18,7 +20,11 @@ services:
     container_name: loki
     ports:
       - "3100:3100"  # Loki API on 3100
+    volumes:
+      - ./loki-config.yml:/etc/loki/local-config.yaml  # Loki config
     command: -config.file=/etc/loki/local-config.yaml
+    environment:
+      - LOKI_RETENTION_PERIOD=24h  # Loki retention period
     restart: always
 
   promtail:
@@ -27,7 +33,10 @@ services:
     volumes:
       - ./promtail/config.yml:/etc/promtail/config.yml  # Your Promtail config
       - ./logs:/var/log/custom  # Folder with your custom logs
-    command: -config.file=/etc/promtail/config.yml
+      - ./promtail-config.yml:/etc/promtail/promtail-config.yml  # Promtail config
+    command: -config.file=/etc/promtail/promtail-config.yml
+    environment:
+      - PROMTAIL_SCRAPE_INTERVAL=10s  # Promtail scrape interval
     restart: always
 
 volumes:

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -8,3 +8,7 @@ datasources:
     isDefault: true
     jsonData:
       maxLines: 1000
+      filters:
+        - observed_timestamp_rfc3339
+        - instrumentation_scope
+        - severity_text

--- a/jenkins
+++ b/jenkins
@@ -32,5 +32,13 @@ pipeline {
                 echo "This is another stage."
             }
         }
+        stage('Deploy Setup') {
+            steps {
+                script {
+                    echo "Deploying the setup using Docker Compose..."
+                    sh 'docker-compose up -d'
+                }
+            }
+        }
     }
 }

--- a/promtail/config.yml
+++ b/promtail/config.yml
@@ -16,3 +16,10 @@ scrape_configs:
         labels:
           job: demo-log-job
           __path__: /var/log/custom/sample-logs.json  # Our mounted log file
+
+pipeline_stages:
+  - json:
+      expressions:
+        observed_timestamp_rfc3339: timestamp
+        instrumentation_scope: scope
+        severity_text: level


### PR DESCRIPTION
Add environment variables and volumes for Grafana, Loki, and Promtail in `docker-compose.yml`.

Add filters for log visualization in `grafana/provisioning/datasources/datasource.yml`.

Add a stage to deploy the setup using Docker Compose in `jenkins`.

Add filters for log visualization in `promtail/config.yml`.

Update `README.md` with instructions for deploying the setup using CI/CD pipeline and information about the filters for log visualization.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/IshanSharmaIshu/devops.1?shareId=XXXX-XXXX-XXXX-XXXX).